### PR TITLE
1.0.8b - fix(asset): asset performance incorrectly calculated

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wallette/web",
   "private": true,
-  "version": "1.0.8",
+  "version": "1.0.8b",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/web/src/pages/asset/detail.tsx
+++ b/apps/web/src/pages/asset/detail.tsx
@@ -440,23 +440,44 @@ export default function AssetDetailPage() {
     assetQuery.data,
     config?.timeFormat,
     config?.dateFormat,
+    config?.numberFormat,
     today,
   ]);
 
   const asset = assetQuery.data;
-  if (!asset) return <div>Asset not found</div>;
+  
+  // Get previous month's balance using React Query
+  const previousMonthBalanceQuery = useSuspenseQuery({
+    queryKey: ["asset-previous-month-balance", id],
+    queryFn: async () => {
+      if (!id) return 0;
+      
+      const previousMonth = dayjs().subtract(1, "month");
+      const previousMonthEnd = previousMonth.endOf("month");
+      
+      // Get the most recent balance from previous month
+      const balances = await db.assetBalances
+        .where("assetId")
+        .equals(Number(id))
+        .and((balance) => 
+          dayjs(balance.date).isBefore(previousMonthEnd.add(1, 'day'), "day")
+        )
+        .sortBy("date");
+      
+      const lastBalance = balances[balances.length - 1];
+      
+      return lastBalance?.balance || asset?.balance || 0;
+    },
+  });
 
   // Calculate performance change for the month
-  const performanceData = performanceQuery.data;
-  const currentBalance =
-    performanceData.length > 0
-      ? performanceData[performanceData.length - 1].balance
-      : asset.balance || 0;
-  const startBalance =
-    performanceData.length > 0 ? performanceData[0].balance : currentBalance;
-  const netWorthChange = currentBalance - startBalance;
+  const currentBalance = asset?.balance || 0;
+  const previousMonthBalance = previousMonthBalanceQuery.data;
+  const netWorthChange = currentBalance - previousMonthBalance;
   const netWorthChangePercent =
-    startBalance !== 0 ? (netWorthChange / startBalance) * 100 : 0;
+    previousMonthBalance !== 0 ? (netWorthChange / previousMonthBalance) * 100 : 0;
+    
+  if (!asset) return <div>Asset not found</div>;
 
   const handleEdit = () => {
     if (!asset) return;

--- a/apps/web/src/pages/asset/detail.tsx
+++ b/apps/web/src/pages/asset/detail.tsx
@@ -450,7 +450,7 @@ export default function AssetDetailPage() {
   const previousMonthBalanceQuery = useSuspenseQuery({
     queryKey: ["asset-previous-month-balance", id],
     queryFn: async () => {
-      if (!id) return 0;
+      if (!id || !asset) return 0;
       
       const previousMonth = dayjs().subtract(1, "month");
       const previousMonthEnd = previousMonth.endOf("month");
@@ -460,13 +460,13 @@ export default function AssetDetailPage() {
         .where("assetId")
         .equals(Number(id))
         .and((balance) => 
-          dayjs(balance.date).isBefore(previousMonthEnd.add(1, 'day'), "day")
+          !dayjs(balance.date).isAfter(previousMonthEnd, "day")
         )
         .sortBy("date");
       
       const lastBalance = balances[balances.length - 1];
       
-      return lastBalance?.balance || asset?.balance || 0;
+      return lastBalance?.balance || 0;
     },
   });
 


### PR DESCRIPTION
This pull request introduces an improvement to the asset performance calculation logic on the asset detail page. The main change is that the monthly performance is now calculated using the previous month's ending balance instead of the first transaction of the month, providing a more accurate representation of net worth change.

### Asset Performance Calculation Improvements

* The asset detail page now fetches the previous month's ending balance using a new React Query call to `db.assetBalances`, and uses this value to calculate monthly performance metrics.
* The calculation for net worth change and percentage change now uses the previous month's ending balance as the baseline, instead of the first transaction of the current month.

### Miscellaneous

* Updated the version in `package.json` from `1.0.8` to `1.0.8b`.